### PR TITLE
Make name of blank disc set the author name when etching

### DIFF
--- a/common/src/main/java/me/jaackson/etched/common/menu/EtchingMenu.java
+++ b/common/src/main/java/me/jaackson/etched/common/menu/EtchingMenu.java
@@ -268,7 +268,8 @@ public class EtchingMenu extends AbstractContainerMenu {
                         labelColor = EtchedMusicDiscItem.getSecondaryColor(discStack);
                         author = EtchedMusicDiscItem.getMusic(discStack).map(EtchedMusicDiscItem.MusicInfo::getAuthor).orElse(null);
                         title = EtchedMusicDiscItem.getMusic(discStack).map(EtchedMusicDiscItem.MusicInfo::getTitle).orElse(null);
-                    }
+                    } else if (discStack.hasCustomHoverName())
+                        author = discStack.getHoverName().getString();
                     if (!labelStack.isEmpty() && labelStack.hasCustomHoverName())
                         title = labelStack.getHoverName().getString();
                     if (SoundCloud.isValidUrl(this.url)) {


### PR DESCRIPTION
I noticed there wasn't a way to set the name of a disc's author if it wasn't pulled from soundcloud, and i thought the name of the blank disc would be good for that since it isn't already used for anything else in the result disc.