### PR TITLE
Update to 1.19.2

### DIFF
--- a/common/src/main/java/gg/moonflower/etched/api/record/PlayableRecordItem.java
+++ b/common/src/main/java/gg/moonflower/etched/api/record/PlayableRecordItem.java
@@ -8,8 +8,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.stats.Stats;
@@ -31,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
 
 public abstract class PlayableRecordItem extends Item implements PlayableRecord {
 
-    private static final Component ALBUM = new TranslatableComponent("item." + Etched.MOD_ID + ".etched_music_disc.album").withStyle(ChatFormatting.DARK_GRAY);
+    private static final Component ALBUM = Component.translatable("item." + Etched.MOD_ID + ".etched_music_disc.album").withStyle(ChatFormatting.DARK_GRAY);
 
     public PlayableRecordItem(Properties properties) {
         super(properties);
@@ -50,7 +48,7 @@ public abstract class PlayableRecordItem extends Item implements PlayableRecord 
             return InteractionResult.PASS;
 
         if (!level.isClientSide()) {
-            ((JukeboxBlock) Blocks.JUKEBOX).setRecord(level, pos, state, stack);
+            ((JukeboxBlock) Blocks.JUKEBOX).setRecord(ctx.getPlayer(), level, pos, state, stack);
             EtchedMessages.PLAY.sendToNear((ServerLevel) level, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, 64, new ClientboundPlayMusicPacket(stack.copy(), pos));
             stack.shrink(1);
             Player player = ctx.getPlayer();
@@ -66,9 +64,9 @@ public abstract class PlayableRecordItem extends Item implements PlayableRecord 
         this.getAlbum(stack).ifPresent(track -> {
             list.add(track.getDisplayName().copy().withStyle(ChatFormatting.GRAY));
             Component brand = SoundSourceManager.getBrandText(track.getUrl())
-                .map(component -> new TextComponent("  ").append(component.copy()))
+                .map(component -> Component.literal("  ").append(component.copy()))
                 .<Component>map(component -> getTrackCount(stack) > 1 ? component.append(" ").append(ALBUM) : component)
-                .orElse(getTrackCount(stack) > 1 ? ALBUM : TextComponent.EMPTY);
+                .orElse(getTrackCount(stack) > 1 ? ALBUM : Component.empty());
             list.add(brand);
         });
     }

--- a/common/src/main/java/gg/moonflower/etched/api/record/TrackData.java
+++ b/common/src/main/java/gg/moonflower/etched/api/record/TrackData.java
@@ -7,8 +7,6 @@ import gg.moonflower.etched.core.Etched;
 import gg.moonflower.pollen.api.util.NbtConstants;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
@@ -23,17 +21,17 @@ import java.util.regex.Pattern;
  */
 public class TrackData {
 
-    public static final TrackData EMPTY = new TrackData(null, "Unknown", new TextComponent("Custom Music"));
+    public static final TrackData EMPTY = new TrackData(null, "Unknown", Component.literal("Custom Music"));
     public static final Codec<TrackData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.STRING.fieldOf("Url").forGetter(TrackData::getUrl),
             Codec.STRING.optionalFieldOf("Author", EMPTY.getArtist()).forGetter(TrackData::getArtist),
             Codec.STRING.optionalFieldOf("Title", Component.Serializer.toJson(EMPTY.getTitle())).<Component>xmap(json -> {
                 if (!json.startsWith("{"))
-                    return new TextComponent(json);
+                    return Component.literal(json);
                 try {
                     return Component.Serializer.fromJson(json);
                 } catch (JsonParseException e) {
-                    return new TextComponent(json);
+                    return Component.literal(json);
                 }
             }, Component.Serializer::toJson).forGetter(TrackData::getTitle)
     ).apply(instance, TrackData::new));
@@ -131,7 +129,7 @@ public class TrackData {
     }
 
     public TrackData withTitle(String title) {
-        return new TrackData(this.url, this.artist, new TextComponent(title));
+        return new TrackData(this.url, this.artist, Component.literal(title));
     }
 
     public TrackData withTitle(Component title) {
@@ -142,6 +140,6 @@ public class TrackData {
      * @return The name to show as the record title
      */
     public Component getDisplayName() {
-        return new TranslatableComponent("sound_source." + Etched.MOD_ID + ".info", this.artist, this.title);
+        return Component.translatable("sound_source." + Etched.MOD_ID + ".info", this.artist, this.title);
     }
 }

--- a/common/src/main/java/gg/moonflower/etched/api/sound/AbstractOnlineSoundInstance.java
+++ b/common/src/main/java/gg/moonflower/etched/api/sound/AbstractOnlineSoundInstance.java
@@ -13,9 +13,11 @@ import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.sounds.AbstractSoundInstance;
 import net.minecraft.client.resources.sounds.Sound;
+import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.*;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.valueproviders.ConstantFloat;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
@@ -44,7 +46,7 @@ public class AbstractOnlineSoundInstance extends AbstractSoundInstance {
     private final boolean stereo;
 
     public AbstractOnlineSoundInstance(String url, @Nullable String subtitle, int attenuationDistance, SoundSource source, DownloadProgressListener progressListener, AudioSource.AudioFileType type, boolean stereo) {
-        super(new ResourceLocation(Etched.MOD_ID, DigestUtils.sha1Hex(url)), source);
+        super(new ResourceLocation(Etched.MOD_ID, DigestUtils.sha1Hex(url)), source, SoundInstance.createUnseededRandom());
         this.url = url;
         this.subtitle = subtitle;
         this.attenuationDistance = attenuationDistance;
@@ -61,7 +63,7 @@ public class AbstractOnlineSoundInstance extends AbstractSoundInstance {
     public WeighedSoundEvents resolve(SoundManager soundManager) {
         WeighedSoundEvents weighedSoundEvents = new WeighedSoundEvents(this.getLocation(), this.subtitle);
         weighedSoundEvents.addSound(new OnlineSound(this.getLocation(), this.url, this.attenuationDistance, this.progressListener, this.type, this.stereo));
-        this.sound = weighedSoundEvents.getSound();
+        this.sound = weighedSoundEvents.getSound(this.random);
         return weighedSoundEvents;
     }
 
@@ -84,7 +86,7 @@ public class AbstractOnlineSoundInstance extends AbstractSoundInstance {
                 return future;
             }
 
-            return soundBufferLibrary.getStream(weighedSoundEvents.getSound().getPath(), loop).thenApply(MonoWrapper::new).handleAsync((stream, e) -> {
+            return soundBufferLibrary.getStream(weighedSoundEvents.getSound(this.random).getPath(), loop).thenApply(MonoWrapper::new).handleAsync((stream, e) -> {
                 if (e != null) {
                     e.printStackTrace();
                     onlineSound.getProgressListener().onFail();
@@ -162,7 +164,7 @@ public class AbstractOnlineSoundInstance extends AbstractSoundInstance {
         private final boolean stereo;
 
         public OnlineSound(ResourceLocation location, String url, int attenuationDistance, DownloadProgressListener progressListener, AudioSource.AudioFileType type, boolean stereo) {
-            super(location.toString(), 1.0F, 1.0F, 1, Type.FILE, true, false, attenuationDistance);
+            super(location.toString(), ConstantFloat.of(1.0F), ConstantFloat.of(1.0F), 1, Type.FILE, true, false, attenuationDistance);
             this.url = url;
             this.progressListener = progressListener;
             this.type = type;

--- a/common/src/main/java/gg/moonflower/etched/api/sound/SoundTracker.java
+++ b/common/src/main/java/gg/moonflower/etched/api/sound/SoundTracker.java
@@ -21,10 +21,9 @@ import net.minecraft.client.sounds.SoundManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.locale.Language;
-import net.minecraft.network.chat.BaseComponent;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.ComponentContents;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.world.entity.Entity;
@@ -52,7 +51,7 @@ import java.util.function.DoubleSupplier;
 public class SoundTracker {
 
     private static final Int2ObjectArrayMap<SoundInstance> ENTITY_PLAYING_SOUNDS = new Int2ObjectArrayMap<>();
-    private static final Component RADIO = new TranslatableComponent("sound_source." + Etched.MOD_ID + ".radio");
+    private static final Component RADIO = Component.translatable("sound_source." + Etched.MOD_ID + ".radio");
 
     private static synchronized void setRecordPlayingNearby(Level level, BlockPos pos, boolean playing) {
         BlockState state = level.getBlockState(pos);
@@ -117,7 +116,7 @@ public class SoundTracker {
 
             @Override
             public void onFail() {
-                PlayableRecord.showMessage(new TranslatableComponent("record." + Etched.MOD_ID + ".downloadFail", title));
+                PlayableRecord.showMessage(Component.translatable("record." + Etched.MOD_ID + ".downloadFail", title));
             }
         }, stream ? AudioSource.AudioFileType.STREAM : AudioSource.AudioFileType.FILE);
     }
@@ -157,7 +156,7 @@ public class SoundTracker {
 
             @Override
             public void onFail() {
-                PlayableRecord.showMessage(new TranslatableComponent("record." + Etched.MOD_ID + ".downloadFail", title));
+                PlayableRecord.showMessage(Component.translatable("record." + Etched.MOD_ID + ".downloadFail", title));
             }
         }, type);
     }
@@ -352,9 +351,9 @@ public class SoundTracker {
         playAlbum(jukebox, jukebox.getBlockState(), level, pos, force);
     }
 
-    private static class DownloadTextComponent extends BaseComponent {
+    private static class DownloadTextComponent extends Component {
 
-        private String text;
+        private ComponentContents text;
         private FormattedCharSequence visualOrderText;
         private Language decomposedWith;
 
@@ -363,13 +362,13 @@ public class SoundTracker {
         }
 
         @Override
-        public String getContents() {
+        public ComponentContents getContents() {
             return text;
         }
 
         @Override
-        public TextComponent plainCopy() {
-            return new TextComponent(this.text);
+        public MutableComponent plainCopy() {
+            return new Component.literal(this.text);
         }
 
         @Environment(EnvType.CLIENT)
@@ -454,19 +453,19 @@ public class SoundTracker {
             if (this.requesting != null) {
                 this.setComponent(this.requesting.copy().append(" " + percentage + "%"));
             } else if (this.size != 0) {
-                this.setComponent(new TranslatableComponent("record." + Etched.MOD_ID + ".downloadProgress", String.format(Locale.ROOT, "%.2f", percentage / 100.0F * this.size), String.format(Locale.ROOT, "%.2f", this.size), this.title));
+                this.setComponent(Component.translatable("record." + Etched.MOD_ID + ".downloadProgress", String.format(Locale.ROOT, "%.2f", percentage / 100.0F * this.size), String.format(Locale.ROOT, "%.2f", this.size), this.title));
             }
         }
 
         @Override
         public void progressStartLoading() {
             this.requesting = null;
-            this.setComponent(new TranslatableComponent("record." + Etched.MOD_ID + ".loading", this.title));
+            this.setComponent(Component.translatable("record." + Etched.MOD_ID + ".loading", this.title));
         }
 
         @Override
         public void onFail() {
-            Minecraft.getInstance().gui.setOverlayMessage(new TranslatableComponent("record." + Etched.MOD_ID + ".downloadFail", this.title), true);
+            Minecraft.getInstance().gui.setOverlayMessage(Component.translatable("record." + Etched.MOD_ID + ".downloadFail", this.title), true);
         }
     }
 }

--- a/common/src/main/java/gg/moonflower/etched/api/sound/SoundTracker.java
+++ b/common/src/main/java/gg/moonflower/etched/api/sound/SoundTracker.java
@@ -20,12 +20,8 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.SoundManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.locale.Language;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.ComponentContents;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.tags.BlockTags;
-import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
@@ -37,6 +33,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.Nullable;
 
+import java.awt.*;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -351,48 +348,6 @@ public class SoundTracker {
         playAlbum(jukebox, jukebox.getBlockState(), level, pos, force);
     }
 
-    private static class DownloadTextComponent extends Component {
-
-        private ComponentContents text;
-        private FormattedCharSequence visualOrderText;
-        private Language decomposedWith;
-
-        public DownloadTextComponent() {
-            this.text = "";
-        }
-
-        @Override
-        public ComponentContents getContents() {
-            return text;
-        }
-
-        @Override
-        public MutableComponent plainCopy() {
-            return new Component.literal(this.text);
-        }
-
-        @Environment(EnvType.CLIENT)
-        public FormattedCharSequence getVisualOrderText() {
-            Language language = Language.getInstance();
-            if (this.decomposedWith != language) {
-                this.visualOrderText = language.getVisualOrder(this);
-                this.decomposedWith = language;
-            }
-
-            return this.visualOrderText;
-        }
-
-        @Override
-        public String toString() {
-            return "TextComponent{text='" + this.text + '\'' + ", siblings=" + this.siblings + ", style=" + this.getStyle() + '}';
-        }
-
-        public void setText(String text) {
-            this.text = text;
-            this.decomposedWith = null;
-        }
-    }
-
     private static abstract class MusicDownloadListener implements DownloadProgressListener {
 
         private final Component title;
@@ -402,7 +357,7 @@ public class SoundTracker {
         private final BlockPos.MutableBlockPos pos;
         private float size;
         private Component requesting;
-        private DownloadTextComponent component;
+        private Component component;
 
         protected MusicDownloadListener(Component title, DoubleSupplier x, DoubleSupplier y, DoubleSupplier z) {
             this.title = title;
@@ -421,11 +376,10 @@ public class SoundTracker {
                 return;
 
             if (this.component == null) {
-                this.component = new DownloadTextComponent();
+                this.component = text.copy();
                 Minecraft.getInstance().gui.setOverlayMessage(this.component, true);
                 ((GuiAccessor) Minecraft.getInstance().gui).setOverlayMessageTime(Short.MAX_VALUE);
             }
-            this.component.setText(text.getString());
         }
 
         protected void clearComponent() {

--- a/common/src/main/java/gg/moonflower/etched/api/sound/download/SoundDownloadSource.java
+++ b/common/src/main/java/gg/moonflower/etched/api/sound/download/SoundDownloadSource.java
@@ -6,7 +6,6 @@ import gg.moonflower.etched.api.util.DownloadProgressListener;
 import gg.moonflower.etched.core.Etched;
 import net.minecraft.SharedConstants;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.packs.resources.ResourceManager;
 import org.jetbrains.annotations.Nullable;
 
@@ -26,7 +25,7 @@ import java.util.Optional;
  */
 public interface SoundDownloadSource {
 
-    Component RESOLVING_TRACKS = new TranslatableComponent("record." + Etched.MOD_ID + ".resolvingTracks");
+    Component RESOLVING_TRACKS = Component.translatable("record." + Etched.MOD_ID + ".resolvingTracks");
 
     /**
      * @return The vanilla Minecraft download headers

--- a/common/src/main/java/gg/moonflower/etched/api/sound/source/AudioSource.java
+++ b/common/src/main/java/gg/moonflower/etched/api/sound/source/AudioSource.java
@@ -6,7 +6,7 @@ import gg.moonflower.etched.api.util.ProgressTrackingInputStream;
 import gg.moonflower.etched.client.sound.SoundCache;
 import gg.moonflower.pollen.api.util.AsyncInputStream;
 import net.minecraft.client.Minecraft;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.util.HttpUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,7 +41,7 @@ public interface AudioSource {
 
     static AsyncInputStream.InputStreamSupplier downloadTo(Path file, URL url, @Nullable DownloadProgressListener progressListener, AudioFileType type) {
         if (progressListener != null)
-            progressListener.progressStartRequest(new TranslatableComponent("resourcepack.requesting"));
+            progressListener.progressStartRequest(Component.translatable("resourcepack.requesting"));
 
         try {
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();

--- a/common/src/main/java/gg/moonflower/etched/client/render/item/AlbumCoverItemRenderer.java
+++ b/common/src/main/java/gg/moonflower/etched/client/render/item/AlbumCoverItemRenderer.java
@@ -36,6 +36,7 @@ import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
+import net.minecraft.util.RandomSource;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.item.ItemStack;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -77,15 +78,13 @@ public class AlbumCoverItemRenderer extends SimplePreparableReloadListener<Album
     }
 
     private static void renderModelLists(BakedModel model, int combinedLight, int combinedOverlay, PoseStack matrixStack, VertexConsumer buffer) {
-        Random random = new Random();
+        RandomSource randomSource = RandomSource.create(42L);
 
         for (Direction direction : Direction.values()) {
-            random.setSeed(42L);
-            renderQuadList(matrixStack, buffer, model.getQuads(null, direction, random), combinedLight, combinedOverlay);
+            renderQuadList(matrixStack, buffer, model.getQuads(null, direction, randomSource), combinedLight, combinedOverlay);
         }
 
-        random.setSeed(42L);
-        renderQuadList(matrixStack, buffer, model.getQuads(null, null, random), combinedLight, combinedOverlay);
+        renderQuadList(matrixStack, buffer, model.getQuads(null, null, randomSource), combinedLight, combinedOverlay);
     }
 
     private static void renderQuadList(PoseStack matrixStack, VertexConsumer buffer, List<BakedQuad> quads, int combinedLight, int combinedOverlay) {

--- a/common/src/main/java/gg/moonflower/etched/client/render/item/AlbumCoverItemRenderer.java
+++ b/common/src/main/java/gg/moonflower/etched/client/render/item/AlbumCoverItemRenderer.java
@@ -95,25 +95,29 @@ public class AlbumCoverItemRenderer extends SimplePreparableReloadListener<Album
     }
 
     private static NativeImage getCoverOverlay(ResourceManager resourceManager) {
-        try (Resource resource = resourceManager.getResource(AlbumCoverItemRenderer.ALBUM_COVER_OVERLAY)) {
-            return NativeImage.read(resource.getInputStream());
-        } catch (IOException e) {
-            e.printStackTrace();
+        Optional<Resource> resource = resourceManager.getResource(AlbumCoverItemRenderer.ALBUM_COVER_OVERLAY);
 
-            NativeImage nativeImage = new NativeImage(16, 16, false);
-            for (int k = 0; k < 16; ++k) {
-                for (int l = 0; l < 16; ++l) {
-                    if (k < 8 ^ l < 8) {
-                        nativeImage.setPixelRGBA(l, k, -524040);
-                    } else {
-                        nativeImage.setPixelRGBA(l, k, -16777216);
-                    }
+        if (resource.isPresent()) {
+            try {
+                return NativeImage.read(resource.get().open());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        NativeImage nativeImage = new NativeImage(16, 16, false);
+        for (int k = 0; k < 16; ++k) {
+            for (int l = 0; l < 16; ++l) {
+                if (k < 8 ^ l < 8) {
+                    nativeImage.setPixelRGBA(l, k, -524040);
+                } else {
+                    nativeImage.setPixelRGBA(l, k, -16777216);
                 }
             }
-
-            nativeImage.untrack();
-            return nativeImage;
         }
+
+        nativeImage.untrack();
+        return nativeImage;
     }
 
     private void close() {

--- a/common/src/main/java/gg/moonflower/etched/client/screen/AlbumJukeboxScreen.java
+++ b/common/src/main/java/gg/moonflower/etched/client/screen/AlbumJukeboxScreen.java
@@ -17,8 +17,6 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
@@ -33,7 +31,7 @@ import java.util.Optional;
 public class AlbumJukeboxScreen extends AbstractContainerScreen<AlbumJukeboxMenu> {
 
     private static final ResourceLocation CONTAINER_LOCATION = new ResourceLocation("textures/gui/container/dispenser.png");
-    private static final Component NOW_PLAYING = new TranslatableComponent("screen." + Etched.MOD_ID + ".album_jukebox.now_playing").withStyle(ChatFormatting.YELLOW);
+    private static final Component NOW_PLAYING = Component.translatable("screen." + Etched.MOD_ID + ".album_jukebox.now_playing").withStyle(ChatFormatting.YELLOW);
 
     private int playingIndex;
     private int playingTrack;
@@ -71,8 +69,8 @@ public class AlbumJukeboxScreen extends AbstractContainerScreen<AlbumJukeboxMenu
         super.init();
 
         int buttonPadding = 6;
-        Component last = new TextComponent("Last");
-        Component next = new TextComponent("Next");
+        Component last = Component.literal("Last");
+        Component next = Component.literal("Next");
         Font font = Minecraft.getInstance().font;
         this.addRenderableWidget(new Button(this.leftPos + 7 + (54 - font.width(last)) / 2 - buttonPadding, this.topPos + 33, font.width(last) + 2 * buttonPadding, 20, last, b -> this.update(false)));
         this.addRenderableWidget(new Button(this.leftPos + 115 + (54 - font.width(last)) / 2 - buttonPadding, this.topPos + 33, font.width(next) + 2 * buttonPadding, 20, next, b -> this.update(true)));

--- a/common/src/main/java/gg/moonflower/etched/client/screen/EditMusicLabelScreen.java
+++ b/common/src/main/java/gg/moonflower/etched/client/screen/EditMusicLabelScreen.java
@@ -9,13 +9,13 @@ import gg.moonflower.etched.common.network.EtchedMessages;
 import gg.moonflower.etched.common.network.play.ServerboundEditMusicLabelPacket;
 import gg.moonflower.etched.core.Etched;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.chat.NarratorChatListener;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
@@ -25,8 +25,8 @@ public class EditMusicLabelScreen extends Screen {
 
     private static final ResourceLocation TEXTURE = new ResourceLocation(Etched.MOD_ID, "textures/gui/edit_music_label.png");
     private static final ResourceLocation LABEL = new ResourceLocation(Etched.MOD_ID, "textures/gui/label.png");
-    private static final TranslatableComponent TITLE_COMPONENT = new TranslatableComponent("screen.etched.edit_music_label.title");
-    private static final TranslatableComponent AUTHOR_COMPONENT = new TranslatableComponent("screen.etched.edit_music_label.author");
+    private static final MutableComponent TITLE_COMPONENT = Component.translatable("screen.etched.edit_music_label.title");
+    private static final MutableComponent AUTHOR_COMPONENT = Component.translatable("screen.etched.edit_music_label.author");
 
     private final Player player;
     private final InteractionHand hand;
@@ -39,7 +39,7 @@ public class EditMusicLabelScreen extends Screen {
     private EditBox author;
 
     public EditMusicLabelScreen(Player player, InteractionHand hand, ItemStack stack) {
-        super(NarratorChatListener.NO_TITLE);
+        super(Component.empty());
         this.player = player;
         this.hand = hand;
         this.labelStack = stack;

--- a/common/src/main/java/gg/moonflower/etched/client/screen/EtchingScreen.java
+++ b/common/src/main/java/gg/moonflower/etched/client/screen/EtchingScreen.java
@@ -20,8 +20,6 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.FormattedCharSequence;
@@ -41,10 +39,10 @@ import java.util.Objects;
 public class EtchingScreen extends AbstractContainerScreen<EtchingMenu> implements ContainerListener {
 
     private static final ResourceLocation TEXTURE = new ResourceLocation(Etched.MOD_ID, "textures/gui/container/etching_table.png");
-    private static final Component INVALID_URL = new TranslatableComponent("screen." + Etched.MOD_ID + ".etching_table.error.invalid_url");
-    private static final Component CANNOT_CREATE = new TranslatableComponent("screen." + Etched.MOD_ID + ".etching_table.error.cannot_create");
-    private static final Component CANNOT_CREATE_MISSING_DISC = new TranslatableComponent("screen." + Etched.MOD_ID + ".etching_table.error.cannot_create.missing_disc").withStyle(ChatFormatting.GRAY);
-    private static final Component CANNOT_CREATE_MISSING_LABEL = new TranslatableComponent("screen." + Etched.MOD_ID + ".etching_table.error.cannot_create.missing_label").withStyle(ChatFormatting.GRAY);
+    private static final Component INVALID_URL = Component.translatable("screen." + Etched.MOD_ID + ".etching_table.error.invalid_url");
+    private static final Component CANNOT_CREATE = Component.translatable("screen." + Etched.MOD_ID + ".etching_table.error.cannot_create");
+    private static final Component CANNOT_CREATE_MISSING_DISC = Component.translatable("screen." + Etched.MOD_ID + ".etching_table.error.cannot_create.missing_disc").withStyle(ChatFormatting.GRAY);
+    private static final Component CANNOT_CREATE_MISSING_LABEL = Component.translatable("screen." + Etched.MOD_ID + ".etching_table.error.cannot_create.missing_label").withStyle(ChatFormatting.GRAY);
 
     private ItemStack discStack;
     private ItemStack labelStack;
@@ -69,7 +67,7 @@ public class EtchingScreen extends AbstractContainerScreen<EtchingMenu> implemen
     protected void init() {
         super.init();
         this.minecraft.keyboardHandler.setSendRepeatsToGui(true);
-        this.url = new EditBox(this.font, this.leftPos + 11, this.topPos + 25, 154, 16,this.url, new TranslatableComponent("container."+Etched.MOD_ID+".etching_table.url"));
+        this.url = new EditBox(this.font, this.leftPos + 11, this.topPos + 25, 154, 16,this.url, Component.translatable("container."+Etched.MOD_ID+".etching_table.url"));
         this.url.setTextColor(-1);
         this.url.setTextColorUneditable(-1);
         this.url.setBordered(false);
@@ -150,7 +148,7 @@ public class EtchingScreen extends AbstractContainerScreen<EtchingMenu> implemen
         } else if ((!this.url.getValue().isEmpty() && !TrackData.isValidURL(this.url.getValue())) || !this.invalidReason.isEmpty()) {
             reasonLines.add(INVALID_URL.getVisualOrderText());
             if (!this.invalidReason.isEmpty())
-                reasonLines.addAll(this.font.split(new TextComponent(this.invalidReason).withStyle(ChatFormatting.GRAY), 200));
+                reasonLines.addAll(this.font.split(Component.literal(this.invalidReason).withStyle(ChatFormatting.GRAY), 200));
         }
 
         if (mouseX >= this.leftPos + 83 && mouseX < this.leftPos + 110 && mouseY >= this.topPos + 44 && mouseY < this.topPos + 61) {

--- a/common/src/main/java/gg/moonflower/etched/client/screen/RadioScreen.java
+++ b/common/src/main/java/gg/moonflower/etched/client/screen/RadioScreen.java
@@ -11,7 +11,6 @@ import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
@@ -34,7 +33,7 @@ public class RadioScreen extends AbstractContainerScreen<RadioMenu> {
     protected void init() {
         super.init();
         this.minecraft.keyboardHandler.setSendRepeatsToGui(true);
-        this.url = new EditBox(this.font, this.leftPos + 10, this.topPos + 21, 154, 16, this.url, new TranslatableComponent("container." + Etched.MOD_ID + ".radio.url"));
+        this.url = new EditBox(this.font, this.leftPos + 10, this.topPos + 21, 154, 16, this.url, Component.translatable("container." + Etched.MOD_ID + ".radio.url"));
         this.url.setTextColor(-1);
         this.url.setTextColorUneditable(-1);
         this.url.setBordered(false);

--- a/common/src/main/java/gg/moonflower/etched/client/sound/EntityRecordSoundInstance.java
+++ b/common/src/main/java/gg/moonflower/etched/client/sound/EntityRecordSoundInstance.java
@@ -1,6 +1,7 @@
 package gg.moonflower.etched.client.sound;
 
 import net.minecraft.client.resources.sounds.AbstractTickableSoundInstance;
+import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.Entity;
@@ -13,7 +14,7 @@ public class EntityRecordSoundInstance extends AbstractTickableSoundInstance {
     private final Entity entity;
 
     public EntityRecordSoundInstance(SoundEvent soundEvent, Entity entity) {
-        super(soundEvent, SoundSource.RECORDS);
+        super(soundEvent, SoundSource.RECORDS, SoundInstance.createUnseededRandom());
         this.volume = 4.0F;
         this.entity = entity;
     }

--- a/common/src/main/java/gg/moonflower/etched/common/block/AlbumJukeboxBlock.java
+++ b/common/src/main/java/gg/moonflower/etched/common/block/AlbumJukeboxBlock.java
@@ -12,6 +12,7 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.Container;
 import net.minecraft.world.Containers;
 import net.minecraft.world.InteractionHand;
@@ -131,7 +132,7 @@ public class AlbumJukeboxBlock extends BaseEntityBlock {
     }
 
     @Override
-    public void animateTick(BlockState state, Level level, BlockPos pos, Random random) {
+    public void animateTick(BlockState state, Level level, BlockPos pos, RandomSource randomSource) {
         if (!Etched.CLIENT_CONFIG.showNotes.get() || !level.getBlockState(pos.above()).isAir())
             return;
 
@@ -146,7 +147,7 @@ public class AlbumJukeboxBlock extends BaseEntityBlock {
         Minecraft minecraft = Minecraft.getInstance();
         Map<BlockPos, SoundInstance> sounds = ((LevelRendererAccessor) minecraft.levelRenderer).getPlayingRecords();
         if (sounds.containsKey(pos) && minecraft.getSoundManager().isActive(sounds.get(pos)))
-            level.addParticle(ParticleTypes.NOTE, pos.getX() + 0.5D, pos.getY() + 1.2D, pos.getZ() + 0.5D, random.nextInt(25) / 24D, 0, 0);
+            level.addParticle(ParticleTypes.NOTE, pos.getX() + 0.5D, pos.getY() + 1.2D, pos.getZ() + 0.5D, randomSource.nextInt(25) / 24D, 0, 0);
     }
 
     @Override

--- a/common/src/main/java/gg/moonflower/etched/common/block/EtchingTableBlock.java
+++ b/common/src/main/java/gg/moonflower/etched/common/block/EtchingTableBlock.java
@@ -5,7 +5,6 @@ import gg.moonflower.etched.core.Etched;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;
@@ -31,7 +30,7 @@ public class EtchingTableBlock extends Block {
 
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
     private static final VoxelShape SHAPE = Block.box(2.0D, 0.0D, 2.0D, 14.0D, 6.0D, 14.0D);
-    private static final Component CONTAINER_TITLE = new TranslatableComponent("container." + Etched.MOD_ID + ".etching_table");
+    private static final Component CONTAINER_TITLE = Component.translatable("container." + Etched.MOD_ID + ".etching_table");
 
     public EtchingTableBlock(Properties properties) {
         super(properties);

--- a/common/src/main/java/gg/moonflower/etched/common/block/RadioBlock.java
+++ b/common/src/main/java/gg/moonflower/etched/common/block/RadioBlock.java
@@ -1,6 +1,5 @@
 package gg.moonflower.etched.common.block;
 
-import gg.moonflower.etched.common.blockentity.AlbumJukeboxBlockEntity;
 import gg.moonflower.etched.common.blockentity.RadioBlockEntity;
 import gg.moonflower.etched.common.menu.RadioMenu;
 import gg.moonflower.etched.common.network.EtchedMessages;
@@ -13,9 +12,9 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.*;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ContainerLevelAccess;
@@ -50,7 +49,7 @@ public class RadioBlock extends BaseEntityBlock {
     private static final VoxelShape X_SHAPE = Block.box(5.0D, 0.0D, 2.0D, 11.0D, 8.0D, 14.0D);
     private static final VoxelShape Z_SHAPE = Block.box(2.0D, 0.0D, 5.0D, 14.0D, 8.0D, 11.0D);
     private static final VoxelShape ROTATED_SHAPE = Block.box(3.0D, 0.0D, 3.0D, 13.0D, 8.0D, 13.0D);
-    private static final Component CONTAINER_TITLE = new TranslatableComponent("container." + Etched.MOD_ID + ".radio");
+    private static final Component CONTAINER_TITLE = Component.translatable("container." + Etched.MOD_ID + ".radio");
 
     public RadioBlock(Properties properties) {
         super(properties);
@@ -169,7 +168,7 @@ public class RadioBlock extends BaseEntityBlock {
     }
 
     @Override
-    public void animateTick(BlockState state, Level level, BlockPos pos, Random random) {
+    public void animateTick(BlockState state, Level level, BlockPos pos, RandomSource randomSource) {
         if (!Etched.CLIENT_CONFIG.showNotes.get() || !level.getBlockState(pos.above()).isAir())
             return;
 
@@ -184,7 +183,7 @@ public class RadioBlock extends BaseEntityBlock {
         Minecraft minecraft = Minecraft.getInstance();
         Map<BlockPos, SoundInstance> sounds = ((LevelRendererAccessor) minecraft.levelRenderer).getPlayingRecords();
         if (sounds.containsKey(pos) && minecraft.getSoundManager().isActive(sounds.get(pos)))
-            level.addParticle(ParticleTypes.NOTE, pos.getX() + 0.5D, pos.getY() + 0.7D, pos.getZ() + 0.5D, random.nextInt(25) / 24D, 0, 0);
+            level.addParticle(ParticleTypes.NOTE, pos.getX() + 0.5D, pos.getY() + 0.7D, pos.getZ() + 0.5D, randomSource.nextInt(25) / 24D, 0, 0);
     }
 
     @Override

--- a/common/src/main/java/gg/moonflower/etched/common/blockentity/AlbumJukeboxBlockEntity.java
+++ b/common/src/main/java/gg/moonflower/etched/common/blockentity/AlbumJukeboxBlockEntity.java
@@ -12,7 +12,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.util.Mth;
 import net.minecraft.world.ContainerHelper;
@@ -183,7 +182,7 @@ public class AlbumJukeboxBlockEntity extends RandomizableContainerBlockEntity im
 
     @Override
     protected Component getDefaultName() {
-        return new TranslatableComponent("container." + Etched.MOD_ID + ".album_jukebox");
+        return Component.translatable("container." + Etched.MOD_ID + ".album_jukebox");
     }
 
     @Override

--- a/common/src/main/java/gg/moonflower/etched/common/entity/MinecartJukebox.java
+++ b/common/src/main/java/gg/moonflower/etched/common/entity/MinecartJukebox.java
@@ -27,6 +27,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.AbstractMinecart;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
@@ -166,8 +167,9 @@ public class MinecartJukebox extends AbstractMinecart implements WorldlyContaine
         return EtchedMessages.PLAY.toVanillaPacket(new ClientboundAddMinecartJukeboxPacket(this), PollinatedPacketDirection.PLAY_CLIENTBOUND);
     }
 
-    public ItemStack getCartItem() {
-        return new ItemStack(EtchedItems.JUKEBOX_MINECART.get());
+    @Override
+    protected Item getDropItem() {
+        return EtchedItems.JUKEBOX_MINECART.get();
     }
 
     @Override

--- a/common/src/main/java/gg/moonflower/etched/common/item/AlbumCoverItem.java
+++ b/common/src/main/java/gg/moonflower/etched/common/item/AlbumCoverItem.java
@@ -10,7 +10,6 @@ import gg.moonflower.pollen.api.util.NbtConstants;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.stats.Stats;

--- a/common/src/main/java/gg/moonflower/etched/common/item/BoomboxItem.java
+++ b/common/src/main/java/gg/moonflower/etched/common/item/BoomboxItem.java
@@ -12,9 +12,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.KeybindComponent;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
@@ -43,9 +40,9 @@ import java.util.Optional;
 public class BoomboxItem extends Item implements ContainerItem {
 
     private static final Map<Integer, ItemStack> PLAYING_RECORDS = new Int2ObjectArrayMap<>();
-    private static final Component PAUSE = new TranslatableComponent("item." + Etched.MOD_ID + ".boombox.pause", new KeybindComponent("key.sneak"), new KeybindComponent("key.use")).withStyle(ChatFormatting.GRAY);
-    private static final Component RECORDS = new TranslatableComponent("item." + Etched.MOD_ID + ".boombox.records");
-    public static final Component PAUSED = new TranslatableComponent("item." + Etched.MOD_ID + ".boombox.paused").withStyle(ChatFormatting.YELLOW);
+    private static final Component PAUSE = Component.translatable("item." + Etched.MOD_ID + ".boombox.pause", Component.keybind("key.sneak"), Component.keybind("key.use")).withStyle(ChatFormatting.GRAY);
+    private static final Component RECORDS = Component.translatable("item." + Etched.MOD_ID + ".boombox.records");
+    public static final Component PAUSED = Component.translatable("item." + Etched.MOD_ID + ".boombox.paused").withStyle(ChatFormatting.YELLOW);
 
     public BoomboxItem(Properties properties) {
         super(properties);
@@ -165,7 +162,7 @@ public class BoomboxItem extends Item implements ContainerItem {
             record.getItem().appendHoverText(record, level, records, isAdvanced);
 
             if (!records.isEmpty()) {
-                tooltipComponents.add(TextComponent.EMPTY);
+                tooltipComponents.add(Component.empty());
                 tooltipComponents.add(RECORDS);
                 tooltipComponents.addAll(records);
             }

--- a/common/src/main/java/gg/moonflower/etched/common/item/SimpleMusicLabelItem.java
+++ b/common/src/main/java/gg/moonflower/etched/common/item/SimpleMusicLabelItem.java
@@ -8,7 +8,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
@@ -82,7 +81,7 @@ public class SimpleMusicLabelItem extends Item {
     @Override
     public void appendHoverText(ItemStack itemStack, @Nullable Level level, List<Component> list, TooltipFlag tooltipFlag) {
         if (!getAuthor(itemStack).isEmpty() && !getTitle(itemStack).isEmpty()) {
-            list.add(new TranslatableComponent("sound_source." + Etched.MOD_ID + ".info", getAuthor(itemStack), getTitle(itemStack)).withStyle(ChatFormatting.GRAY));
+            list.add(Component.translatable("sound_source." + Etched.MOD_ID + ".info", getAuthor(itemStack), getTitle(itemStack)).withStyle(ChatFormatting.GRAY));
         }
     }
 }

--- a/common/src/main/java/gg/moonflower/etched/common/menu/RadioMenu.java
+++ b/common/src/main/java/gg/moonflower/etched/common/menu/RadioMenu.java
@@ -6,6 +6,7 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.item.ItemStack;
 
 import java.util.function.Consumer;
 
@@ -13,7 +14,6 @@ import java.util.function.Consumer;
  * @author Ocelot
  */
 public class RadioMenu extends AbstractContainerMenu {
-
     private final ContainerLevelAccess access;
     // Workaround for thread concurrency issues
     private final Consumer<String> urlConsumer;
@@ -27,6 +27,12 @@ public class RadioMenu extends AbstractContainerMenu {
         super(EtchedMenus.RADIO_MENU.get(), id);
         this.access = access;
         this.urlConsumer = containerLevelAccess;
+    }
+
+
+    @Override
+    public ItemStack quickMoveStack(Player player, int sourceSlotIndex) {
+        return ItemStack.EMPTY;
     }
 
     @Override

--- a/common/src/main/java/gg/moonflower/etched/common/network/play/handler/EtchedClientPlayPacketHandlerImpl.java
+++ b/common/src/main/java/gg/moonflower/etched/common/network/play/handler/EtchedClientPlayPacketHandlerImpl.java
@@ -65,7 +65,7 @@ public class EtchedClientPlayPacketHandlerImpl implements EtchedClientPlayPacket
         ctx.enqueueWork(() -> {
             MinecartJukebox entity = new MinecartJukebox(level, pkt.getX(), pkt.getY(), pkt.getZ());
             int i = pkt.getId();
-            entity.setPacketCoordinates(pkt.getX(), pkt.getY(), pkt.getZ());
+            entity.syncPacketPositionCodec(pkt.getX(), pkt.getY(), pkt.getZ());
             entity.moveTo(pkt.getX(), pkt.getY(), pkt.getZ());
             entity.setXRot((float) (pkt.getxRot() * 360) / 256.0F);
             entity.setYRot((float) (pkt.getyRot() * 360) / 256.0F);

--- a/common/src/main/java/gg/moonflower/etched/common/sound/download/BandcampSource.java
+++ b/common/src/main/java/gg/moonflower/etched/common/sound/download/BandcampSource.java
@@ -11,8 +11,6 @@ import gg.moonflower.etched.api.util.ProgressTrackingInputStream;
 import gg.moonflower.etched.core.Etched;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextColor;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.GsonHelper;
 import org.apache.commons.io.IOUtils;
@@ -33,14 +31,14 @@ import java.util.regex.Pattern;
 public class BandcampSource implements SoundDownloadSource {
 
     private static final Pattern DATA_PATTERN = Pattern.compile("data-tralbum=\"([^\"]+)\"");
-    private static final Component BRAND = new TranslatableComponent("sound_source." + Etched.MOD_ID + ".bandcamp").withStyle(style -> style.withColor(TextColor.fromRgb(0x477987)));
+    private static final Component BRAND = Component.translatable("sound_source." + Etched.MOD_ID + ".bandcamp").withStyle(style -> style.withColor(TextColor.fromRgb(0x477987)));
 
     private final Map<String, Boolean> validCache = new WeakHashMap<>();
 
     private InputStream get(String url, @Nullable DownloadProgressListener progressListener, Proxy proxy) throws IOException {
         HttpURLConnection httpURLConnection;
         if (progressListener != null)
-            progressListener.progressStartRequest(new TranslatableComponent("sound_source." + Etched.MOD_ID + ".requesting", this.getApiName()));
+            progressListener.progressStartRequest(Component.translatable("sound_source." + Etched.MOD_ID + ".requesting", this.getApiName()));
 
         try {
             URL uRL = new URL(url);
@@ -118,18 +116,18 @@ public class BandcampSource implements SoundDownloadSource {
             if ("album".equals(type)) {
                 JsonArray trackInfoJson = GsonHelper.getAsJsonArray(json, "trackinfo");
                 List<TrackData> tracks = new ArrayList<>(trackInfoJson.size());
-                tracks.add(new TrackData(url, artist, new TextComponent(title)));
+                tracks.add(new TrackData(url, artist, Component.literal(title)));
                 for (int i = 0; i < trackInfoJson.size(); i++) {
                     JsonObject trackJson = GsonHelper.convertToJsonObject(trackInfoJson.get(i), "trackinfo[" + i + "]");
                     String trackUrl = url.substring(0, urlEnd + 4) + GsonHelper.getAsString(trackJson, "title_link");
                     String trackArtist = trackJson.has("artist") && !trackJson.get("artist").isJsonNull() ? StringEscapeUtils.unescapeHtml4(GsonHelper.getAsString(trackJson, "artist", artist)) : artist;
                     String trackTitle = StringEscapeUtils.unescapeHtml4(GsonHelper.getAsString(trackJson, "title"));
 
-                    tracks.add(new TrackData(trackUrl, trackArtist, new TextComponent(trackTitle)));
+                    tracks.add(new TrackData(trackUrl, trackArtist, Component.literal(trackTitle)));
                 }
                 return tracks.toArray(new TrackData[0]);
             }
-            return new TrackData[]{new TrackData(url, artist, new TextComponent(title))};
+            return new TrackData[]{new TrackData(url, artist, Component.literal(title))};
         });
     }
 

--- a/common/src/main/java/gg/moonflower/etched/common/sound/download/SoundCloudSource.java
+++ b/common/src/main/java/gg/moonflower/etched/common/sound/download/SoundCloudSource.java
@@ -12,8 +12,6 @@ import gg.moonflower.etched.api.util.ProgressTrackingInputStream;
 import gg.moonflower.etched.core.Etched;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextColor;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.GsonHelper;
 import org.apache.logging.log4j.LogManager;
@@ -33,7 +31,7 @@ import java.util.*;
 public class SoundCloudSource implements SoundDownloadSource {
 
     static final Logger LOGGER = LogManager.getLogger();
-    private static final Component BRAND = new TranslatableComponent("sound_source." + Etched.MOD_ID + ".sound_cloud").withStyle(style -> style.withColor(TextColor.fromRgb(0xFF5500)));
+    private static final Component BRAND = Component.translatable("sound_source." + Etched.MOD_ID + ".sound_cloud").withStyle(style -> style.withColor(TextColor.fromRgb(0xFF5500)));
 
     private final Map<String, Boolean> validCache = new WeakHashMap<>();
 
@@ -45,7 +43,7 @@ public class SoundCloudSource implements SoundDownloadSource {
     private InputStream get(String url, @Nullable DownloadProgressListener progressListener, Proxy proxy, int attempt, boolean requiresId) throws IOException {
         HttpURLConnection httpURLConnection;
         if (progressListener != null)
-            progressListener.progressStartRequest(new TranslatableComponent("sound_source." + Etched.MOD_ID + ".requesting", this.getApiName()));
+            progressListener.progressStartRequest(Component.translatable("sound_source." + Etched.MOD_ID + ".requesting", this.getApiName()));
 
         try {
             URL uRL = requiresId ? appendUri(url, "client_id=" + SoundCloudIdTracker.fetch(proxy)) : new URL(url);
@@ -134,7 +132,7 @@ public class SoundCloudSource implements SoundDownloadSource {
             if ("playlist".equals(kind)) {
                 JsonArray tracksJson = GsonHelper.getAsJsonArray(json, "tracks");
                 List<TrackData> tracks = new ArrayList<>();
-                tracks.add(new TrackData(url, artist, new TextComponent(title)));
+                tracks.add(new TrackData(url, artist, Component.literal(title)));
 
                 for (int i = 0; i < tracksJson.size(); i++) {
                     try {
@@ -145,7 +143,7 @@ public class SoundCloudSource implements SoundDownloadSource {
                         String trackUrl = GsonHelper.getAsString(trackJson, "permalink_url");
                         String trackArtist = GsonHelper.getAsString(trackUser, "username");
                         String trackTitle = GsonHelper.getAsString(trackJson, "title");
-                        tracks.add(new TrackData(trackUrl, trackArtist, new TextComponent(trackTitle)));
+                        tracks.add(new TrackData(trackUrl, trackArtist, Component.literal(trackTitle)));
                     } catch (JsonParseException e) {
                         LOGGER.error("Failed to parse track: " + url + "[" + i + "]", e);
                     }
@@ -154,7 +152,7 @@ public class SoundCloudSource implements SoundDownloadSource {
                 return tracks.toArray(new TrackData[0]);
             }
 
-            return new TrackData[]{new TrackData(url, artist, new TextComponent(title))};
+            return new TrackData[]{new TrackData(url, artist, Component.literal(title))};
         });
     }
 

--- a/common/src/main/java/gg/moonflower/etched/core/Etched.java
+++ b/common/src/main/java/gg/moonflower/etched/core/Etched.java
@@ -21,6 +21,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
@@ -28,6 +29,9 @@ import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
+
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Jackson
@@ -104,7 +108,7 @@ public class Etched {
         ClientLoading.load(); // stops server from crashing due to client loading
         ModelRegistry.registerFactory((resourceManager, out) -> {
             String folder = "models/item/" + AlbumCoverItemRenderer.FOLDER_NAME + "/";
-            for (ResourceLocation animationLocation : resourceManager.listResources(folder, name -> name.endsWith(".json")))
+            for (ResourceLocation animationLocation : resourceManager.listResources(folder, name -> name.toString().endsWith(".json")).keySet())
                 out.accept(new ModelResourceLocation(new ResourceLocation(animationLocation.getNamespace(), animationLocation.getPath().substring(12, animationLocation.getPath().length() - 5)), "inventory"));
         });
 

--- a/common/src/main/java/gg/moonflower/etched/core/mixin/JukeboxBlockMixin.java
+++ b/common/src/main/java/gg/moonflower/etched/core/mixin/JukeboxBlockMixin.java
@@ -9,6 +9,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.RecordItem;
 import net.minecraft.world.level.Level;
@@ -44,12 +45,12 @@ public abstract class JukeboxBlockMixin extends BaseEntityBlock {
 
     @Override
     @Environment(EnvType.CLIENT)
-    public void animateTick(BlockState state, Level level, BlockPos pos, Random random) {
+    public void animateTick(BlockState state, Level level, BlockPos pos, RandomSource randomSource) {
         if (state.getValue(JukeboxBlock.HAS_RECORD) && Etched.CLIENT_CONFIG.showNotes.get() && level.getBlockState(pos.above()).isAir()) {
             Minecraft minecraft = Minecraft.getInstance();
             Map<BlockPos, SoundInstance> sounds = ((LevelRendererAccessor) minecraft.levelRenderer).getPlayingRecords();
             if (sounds.containsKey(pos) && minecraft.getSoundManager().isActive(sounds.get(pos)))
-                level.addParticle(ParticleTypes.NOTE, pos.getX() + 0.5D, pos.getY() + 1.2D, pos.getZ() + 0.5D, random.nextInt(25) / 24D, 0, 0);
+                level.addParticle(ParticleTypes.NOTE, pos.getX() + 0.5D, pos.getY() + 1.2D, pos.getZ() + 0.5D, randomSource.nextInt(25) / 24D, 0, 0);
         }
     }
 }

--- a/common/src/main/java/gg/moonflower/etched/core/mixin/RecordItemMixin.java
+++ b/common/src/main/java/gg/moonflower/etched/core/mixin/RecordItemMixin.java
@@ -12,8 +12,6 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.entity.Entity;
@@ -33,12 +31,12 @@ public abstract class RecordItemMixin extends Item implements PlayableRecord {
 
     @Unique
     private final Supplier<TrackData[]> track = Suppliers.memoize(() -> {
-        Component desc = new TranslatableComponent(this.getDescriptionId() + ".desc");
+        Component desc = Component.translatable(this.getDescriptionId() + ".desc");
 
         String[] parts = desc.getString().split("-", 2);
         if (parts.length < 2)
             return new TrackData[]{new TrackData(((SoundEventAccessor) RecordItemHook.getSound((RecordItem) (Object) this)).getLocation().toString(), "Minecraft", desc)};
-        return new TrackData[]{new TrackData(((SoundEventAccessor) RecordItemHook.getSound((RecordItem) (Object) this)).getLocation().toString(), parts[0].trim(), new TextComponent(parts[1].trim()).withStyle(desc.getStyle()))};
+        return new TrackData[]{new TrackData(((SoundEventAccessor) RecordItemHook.getSound((RecordItem) (Object) this)).getLocation().toString(), parts[0].trim(), Component.literal(parts[1].trim()).withStyle(desc.getStyle()))};
     });
 
     private RecordItemMixin(Properties properties) {

--- a/common/src/main/java/gg/moonflower/etched/core/mixin/RecordItemMixin.java
+++ b/common/src/main/java/gg/moonflower/etched/core/mixin/RecordItemMixin.java
@@ -13,6 +13,7 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.Item;
@@ -63,7 +64,9 @@ public abstract class RecordItemMixin extends Item implements PlayableRecord {
     @Environment(EnvType.CLIENT)
     public CompletableFuture<AlbumCover> getAlbumCover(ItemStack stack, Proxy proxy, ResourceManager resourceManager) {
         ResourceLocation key = Registry.ITEM.getKey(this);
-        return resourceManager.hasResource(new ResourceLocation(key.getNamespace(), "models/item/" + AlbumCoverItemRenderer.FOLDER_NAME + "/" + key.getPath() + ".json")) ? CompletableFuture.completedFuture(AlbumCover.of(new ResourceLocation(key.getNamespace(), AlbumCoverItemRenderer.FOLDER_NAME + "/" + key.getPath()))) : CompletableFuture.completedFuture(AlbumCover.EMPTY);
+        Optional<Resource> resource = resourceManager.getResource(new ResourceLocation(key.getNamespace(), "models/item/" + AlbumCoverItemRenderer.FOLDER_NAME + "/" + key.getPath() + ".json"));
+
+        return resource.isPresent() ? CompletableFuture.completedFuture(AlbumCover.of(new ResourceLocation(key.getNamespace(), AlbumCoverItemRenderer.FOLDER_NAME + "/" + key.getPath()))) : CompletableFuture.completedFuture(AlbumCover.EMPTY);
     }
 
     @Override

--- a/common/src/main/java/gg/moonflower/etched/core/mixin/StructureTemplatePoolAccessor.java
+++ b/common/src/main/java/gg/moonflower/etched/core/mixin/StructureTemplatePoolAccessor.java
@@ -1,6 +1,7 @@
 package gg.moonflower.etched.core.mixin;
 
 import com.mojang.datafixers.util.Pair;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.world.level.levelgen.structure.pools.StructurePoolElement;
 import net.minecraft.world.level.levelgen.structure.pools.StructureTemplatePool;
 import org.spongepowered.asm.mixin.Mixin;
@@ -12,7 +13,7 @@ import java.util.List;
 public interface StructureTemplatePoolAccessor {
 
     @Accessor
-    List<StructurePoolElement> getTemplates();
+    ObjectArrayList<StructurePoolElement> getTemplates();
 
     @Accessor
     List<Pair<StructurePoolElement, Integer>> getRawTemplates();

--- a/common/src/main/java/gg/moonflower/etched/core/mixin/client/ItemStackMixin.java
+++ b/common/src/main/java/gg/moonflower/etched/core/mixin/client/ItemStackMixin.java
@@ -4,7 +4,6 @@ import gg.moonflower.etched.common.item.BoomboxItem;
 import gg.moonflower.etched.core.Etched;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;

--- a/common/src/main/java/gg/moonflower/etched/core/registry/EtchedTags.java
+++ b/common/src/main/java/gg/moonflower/etched/core/registry/EtchedTags.java
@@ -3,7 +3,6 @@ package gg.moonflower.etched.core.registry;
 import gg.moonflower.etched.core.Etched;
 import gg.moonflower.pollen.api.registry.resource.TagRegistry;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
 

--- a/common/src/main/java/gg/moonflower/etched/core/registry/EtchedVillagers.java
+++ b/common/src/main/java/gg/moonflower/etched/core/registry/EtchedVillagers.java
@@ -9,7 +9,9 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.data.BuiltinRegistries;
 import net.minecraft.data.worldgen.*;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.ai.village.poi.PoiType;
 import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.level.block.Blocks;
@@ -19,6 +21,7 @@ import net.minecraft.world.level.levelgen.structure.pools.StructureTemplatePool;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorList;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 public class EtchedVillagers {
@@ -26,8 +29,19 @@ public class EtchedVillagers {
     public static final PollinatedRegistry<VillagerProfession> PROFESSIONS = PollinatedRegistry.create(Registry.VILLAGER_PROFESSION, Etched.MOD_ID);
     public static final PollinatedRegistry<PoiType> POI_TYPES = PollinatedRegistry.create(Registry.POINT_OF_INTEREST_TYPE, Etched.MOD_ID);
 
-    public static final Supplier<PoiType> BARD_POI = POI_TYPES.register("bard", () -> PoiType.registerBlockStates(new PoiType("etched:bard", ImmutableSet.<BlockState>builder().addAll(Blocks.NOTE_BLOCK.getStateDefinition().getPossibleStates()).build(), 1, 1)));
-    public static final Supplier<VillagerProfession> BARD = PROFESSIONS.register("bard", () -> new VillagerProfession("etched:bard", BARD_POI.get(), ImmutableSet.of(), ImmutableSet.of(), null));
+    public static final Supplier<PoiType> BARD_POI = POI_TYPES.register("bard", () -> new PoiType(ImmutableSet.copyOf(Blocks.NOTE_BLOCK.getStateDefinition().getPossibleStates()), 1, 1));
+    public static final Supplier<VillagerProfession> BARD = PROFESSIONS.register("bard", () -> new VillagerProfession("etched:bard", () -> {
+        ResourceKey<PoiType> key = Objects.requireNonNull(BARD_POI.getKey());
+
+        return new VillagerProfession(
+            "bard",
+            holder -> holder.is(key),
+            holder -> holder.is(key),
+            ImmutableSet.of(),
+            ImmutableSet.of(),
+            null
+        );
+    }));
 
     public static void registerVillages() {
         PlainVillagePools.bootstrap();

--- a/fabric/src/main/java/gg/moonflower/etched/core/fabric/EtchedFabricClient.java
+++ b/fabric/src/main/java/gg/moonflower/etched/core/fabric/EtchedFabricClient.java
@@ -15,13 +15,15 @@ public class EtchedFabricClient implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
-        ClientPickBlockGatherCallback.EVENT.register((player, result) -> {
+        // @todo: Make sure the new method AbstractMinecart#getDropItem() is used instead of this
+
+        /*ClientPickBlockGatherCallback.EVENT.register((player, result) -> {
             if (result.getType() == HitResult.Type.ENTITY && player.getAbilities().instabuild) {
                 Entity entity = ((EntityHitResult) result).getEntity();
                 if (entity instanceof MinecartJukebox)
                     return ((MinecartJukebox) entity).getCartItem();
             }
             return ItemStack.EMPTY;
-        });
+        });*/
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,15 +9,15 @@ mod_version=2.2.0
 maven_group=gg.moonflower
 
 # Dependencies
-minecraft_version=1.18.2
+minecraft_version=1.19.2
 pollen_version=1.4.8+1.18.2
-parchment_version=2021.10.31
+parchment_version=2022.08.14
 devauth_version=1.1.0
 
 # Forge
-forge_version=40.1.0
+forge_version=43.1.0
 
 # Fabric
-fabric_loader_version=0.14.8
-fabric_api_version=0.57.0+1.18.2
+fabric_loader_version=0.14.21
+fabric_api_version=0.76.0+1.19.2
 mod_menu_version=3.2.3


### PR DESCRIPTION
### Description

This pull request covers some necessary changes for Ethed to work on 1.19.2. There are some simple fixes like changing translatable component constructors, changed Villager POI, changed Resource accessor that now returns Optional.

Unfortunately, I was not able to create a build for 1.19.2 to test it, due to missing Pollen dependency. I know there's a 1.19.2 code of Pollen on https://github.com/MoonflowerTeam/pollen/tree/2.0, but my build of Pollen 2.0 fails due to missing dependencies:

```
gg.moonflower.pinwheel:pinwheel:1.0.0
com.github.Ocelot5836:molang-compiler:master-SNAPSHOT
```

Therefore I cannot claim that this is a proper port for 1.19.2. I believe if I will be able to get Pollen building on 1.19.2 I will be able to make a proper 1.19.2 version.

### Known errors

Currently, there are two errors on build, due to non-updated Pollen dependency. One is related to the Villager POI, as the construction method changed, we need to use Resource key from `PollinatedRegistry`, and another due to `AbstractMinecart` target mismatch.

### Pay attention to

* Minecart drops;
* Download text;
* StructureTemplatePool accessor;
* Tags in `EtchedTags` as they were removed.