### PR TITLE
Support audio files on Google Drive

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ parchment_version=2023.09.03
 
 ## Mod
 mod_id=etched
-mod_version=3.0.2
+mod_version=3.0.3
 mod_name=Etched
 mod_description=A new form of entertainment.
 archives_base_name=etched


### PR DESCRIPTION
Google Drive sets `max-age=0` in the header and serves a file instead of a stream, so we check for a non-zero content length and continue if it's a file.